### PR TITLE
Update .cocciconfig

### DIFF
--- a/.cocciconfig
+++ b/.cocciconfig
@@ -1,3 +1,3 @@
 [spatch]
-	options = --timeout 200
+	options = --timeout 100
 	options = --use-gitgrep


### PR DESCRIPTION
Reduce the default spatch --timeout from 200 seconds to 100 seconds to improve responsiveness, shorten feedback loops for developers, and lower CPU usage in CI by aborting long-running or stalled Coccinelle rules sooner. This stricter limit helps prevent individual SmPL scripts from blocking jobs for several minutes, encourages optimization and scope-limiting of patterns, and reduces the likelihood of unpredictable timeouts or resource contention in shared environments. Legitimate complex rules that require more time can still be run locally or in a dedicated CI job with a higher timeout, ensuring flexibility without keeping the higher default cost for all runs.